### PR TITLE
Modified keyword to list plugin in the plugin browser on gulpjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "keywords": [
     "svg",
     "sprites",
-    "gulp-plugin"
+    "gulpplugin"
   ],
   "devDependencies": {
     "vinyl-fs": "^0.1.0",


### PR DESCRIPTION
Gulp only fetches data from npmsearch with the keywords _gulpplugin_ and _gulpfriendly_.
