### PR TITLE
Add note about node-gyp for windows installs to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Install it locally to your project.
 $ npm install gulp-svg-sprites
 ```
 
+**Windows note:** Make sure, you also have all [prerequisities for node-gyp](https://github.com/TooTallNate/node-gyp#installation).
+
 ##Usage
 With no configuration, `gulp-svg-sprites` will create the following files:
 


### PR DESCRIPTION
For now, windows install looks something like this:
1. You will get install error, because you don't have python installed.
2. You will install newest python from python site. You will struggle for a while with pythons env paths.
3. You will get another install error, because you are using too new python.
4. You will install older python from pythons site. You will struggle little bit more with pythons env paths, because you now have two python version installed.
5. You will get another install error, because you don't have .NET 2.0 SDK.
6. You will download .NET 2.0 SDK and find out, that the setup won't even start up in Win 8.
7. If you didn't gave up yet, you will start digging into node modules and after a while, you'll find, that node-gyp actually require you to install whole Visual Studio. :)

The note in readme could at least prevent some of those install struggles. It's still bummer though, that on Windows, you still need to install whole Visual Studio (4GB) to use this tool. I don't know, if you can use something else instead of node-gyp?

Anyway, thanks for awesome tool!
