### PR TITLE
Output padded items offset the correct amount

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,11 +212,11 @@ function transformData(data, config) {
 
     data.svg = data.svg.map(function (item) {
 
-        item.relHeight = item.height/10 + (2*config.padding)/10;
-        item.relWidth  = item.width/10 + (2*config.padding)/10;
+        item.relHeight = item.height/10;
+        item.relWidth  = item.width/10;
 
-        item.relPositionX = item.positionX/10;
-        item.relPositionY = item.positionY/10;
+        item.relPositionX = item.positionX/10 - config.padding/10;
+        item.relPositionY = item.positionY/10 - config.padding/10;
         item.normal = true;
 
         if (item.name.match(/~/g)) {


### PR DESCRIPTION
Apologies, I kind of screwed up in my last pull request. What I previously did was add extra height and width to the items size to account for the padding. This obviously made items bigger than they should be.

Now I've removed that and just offset the background position by the padding amount. This means that the item's size stays the same as the original image.
