### PR TITLE
Output sprite css file to multiple locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gulp-svg-sprites
+# gulp-svg-sprites [![Build Status](https://travis-ci.org/shakyShane/gulp-svg-sprites.svg?branch=master)](https://travis-ci.org/shakyShane/gulp-svg-sprites)
 
 Gulp plugin for working with SVGs
 

--- a/index.js
+++ b/index.js
@@ -212,8 +212,8 @@ function transformData(data, config) {
 
     data.svg = data.svg.map(function (item) {
 
-        item.relHeight = item.height/10;
-        item.relWidth  = item.width/10;
+	item.relHeight = item.height/10 + (2*config.padding)/10;
+	item.relWidth  = item.width/10 + (2*config.padding)/10;
 
         item.relPositionX = item.positionX/10;
         item.relPositionY = item.positionY/10;

--- a/index.js
+++ b/index.js
@@ -207,6 +207,12 @@ function getTemplates(config) {
  */
 function transformData(data, config) {
 
+    // Set preview css file to first submitted path
+    if (typeof(config.cssFile) === "object") {
+	config.cssFileObj = config.cssFile;
+	config.cssFile = config.cssFile[0];
+    }
+
     data.svgPath = config.svgPath.replace("%f", config.svg.sprite);
     data.pngPath = config.pngPath.replace("%f", config.svg.sprite.replace(/\.svg$/, ".png"));
 
@@ -280,8 +286,14 @@ function writeFiles(stream, config, svg, data, cb) {
             contents: new Buffer(svg)
         }));
 
-        if (config.cssFile) {
-            promises.push(makeFile(temps.css, config.cssFile, stream, data));
+	if (config.cssFile) {
+	    if ( config.cssFileObj ) {
+		_(config.cssFileObj).forEach(function(cssFile) {
+		    promises.push(makeFile( temps.css, cssFile, stream, data));
+		});
+	    } else {
+		promises.push(makeFile(temps.css, config.cssFile, stream, data));
+	    }
         }
 
         if (config.preview && config.preview.sprite) {

--- a/index.js
+++ b/index.js
@@ -223,9 +223,12 @@ function transformData(data, config) {
             if (config.mode !== "sprite") {
                 return false;
             } else {
-                item.name = item.name.replace("~", ":");
+		var segs  = item.name.split("~");
+		item.name = item.selector[0].expression + ":" + segs[1];
                 item.normal = false;
             }
+	} else {
+	    item.name = item.selector[0].expression;
         }
 
         return item;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-svg-sprites",
   "description": "Create SVG sprites with PNG fallbacks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-svg-sprites",
   "description": "Create SVG sprites with PNG fallbacks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-svg-sprites",
   "description": "Create SVG sprites with PNG fallbacks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "through2": "^0.4.1",
     "vinyl": "^0.2.3",
     "gulp-util": "^3.0.0",
-    "svg-sprite-data": "0.0.3",
+    "svg-sprite-data": "0.0.5",
     "dust": "^0.3.0",
     "dustjs-linkedin": "^2.4.0",
     "q": "^1.0.1"


### PR DESCRIPTION
This allows the user to output the sprite file to multiple locations.

For instance, I have it set as `cssFile: ["css/sprites.css", "scss/components/_sprites.scss"]`, allowing for a preview compatible CSS file, and an scss file which integrates with my Sass system. The first array item is submitted to the preview document.

Admittedly, it's a niche feature, but I find it very handy.
