### PR TITLE
A start on loader script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gulp.task('sprites', function () {
 
 ##Symbols mode
 Pass `mode: "symbols"` to output SVG data as this [CSS TRICKS article](http://css-tricks.com/svg-symbol-good-choice-icons/) outlines.
-You'll get an SVG file & a preview file showing how to use it.
+You'll get an SVG file, a loader script, and a preview file showing how to use it.
 
 ```js
 gulp.task('sprites', function () {
@@ -72,7 +72,7 @@ gulp.task('sprites', function () {
 
 ##Defs mode
 Pass `mode: "defs"` to output SVG data as this [CSS TRICKS article](http://css-tricks.com/svg-sprites-use-better-icon-fonts/) outlines.
-You'll get an SVG file & a preview file showing how to use it.
+You'll get an SVG file, a loader script, and a preview file showing how to use it.
 
 ```js
 gulp.task('sprites', function () {
@@ -108,6 +108,19 @@ gulp.task('sprites', function () {
 });
 ```
 
+###Loader Path
+Tell the loader script the relative path to your SVG file from wherever you are going to use the script -- the path the XML request will need to use to fetch the SVG. This is handy because you probably should be copying-and-pasting the script into existing JS or directly into your markup, rather than using the generated file as it is.
+
+```js
+gulp.task('sprites', function () {
+    return gulp.src('assets/svg/*.svg')
+        .pipe(svgSprite({
+            loaderPath: 'assets/svg/symbols.svg'
+        }))
+        .pipe(gulp.dest('assets'));
+});
+``` 
+
 ###Custom filenames
 Change the generated filenames with ease. For example, if you want to create a `scss` partial instead, you could just do:
  
@@ -128,6 +141,15 @@ gulp.task('sprites', function () {
             svg: {
                 sprite: "svg.svg"
             }
+        }))
+        .pipe(gulp.dest("assets"));
+});
+
+// Custom loader filename
+gulp.task('sprites', function () {
+    return gulp.src('assets/svg/*.svg')
+        .pipe(svgSprite({
+            loader: "customLoader.js"
         }))
         .pipe(gulp.dest("assets"));
 });

--- a/index.js
+++ b/index.js
@@ -162,7 +162,25 @@ var defaults = {
      */
     afterTransform: function (data, config) {
         return data;
-    }
+    },
+    /**
+     *
+     * Filename of generated JS loader script, for defs and symbols mode.
+     *
+     * @property loader
+     * @type String
+     * @default loader.js
+     */
+    loader: "loader.js",
+    /**
+     *
+     * Path in loader script to the SVG file to load.
+     *
+     * @property loaderPath
+     * @type String
+     * @default %f
+     */
+    loaderPath: "%f"
 };
 
 /**
@@ -175,7 +193,8 @@ var templatePaths = {
     symbols:        "/tmpl/symbols.svg",
     previewSprite:  "/tmpl/preview.html",
     previewDefs:    "/tmpl/preview-defs.html",
-    previewSymbols: "/tmpl/preview-symbol.html"
+    previewSymbols: "/tmpl/preview-symbol.html",
+    loader:         "/tmpl/loader.js"
 };
 
 /**
@@ -209,6 +228,8 @@ function transformData(data, config) {
 
     data.svgPath = config.svgPath.replace("%f", config.svg.sprite);
     data.pngPath = config.pngPath.replace("%f", config.svg.sprite.replace(/\.svg$/, ".png"));
+    data.loaderPath = (config.mode === "symbols") ? config.loaderPath.replace("%f", config.svg.symbols)
+        : config.loaderPath.replace("%f", config.svg.defs);
 
     data.svg = data.svg.map(function (item) {
 
@@ -304,8 +325,15 @@ function writeFiles(stream, config, svg, data, cb) {
 
         data.svgInline = output;
 
+        if (config.loader) {
+            promises.push(makeFile(temps.loader, config.loader, stream, data));
+        }
+
         if (config.preview && config.preview[config.mode]) {
             promises.push(makeFile(temps[preview], config.preview[template], stream, data));
+        }
+
+        if (promises.length) {
             Q.all(promises).then(cb);
         } else {
             cb(null);

--- a/test/specs/defs.js
+++ b/test/specs/defs.js
@@ -12,6 +12,7 @@ describe("Sending Correct files downstream", function () {
 
         streamTester(config, [
             "svg/defs.svg",
+            "loader.js",
             "defs.html"
         ], done);
     });
@@ -26,6 +27,7 @@ describe("Sending Correct files downstream", function () {
 
         streamTester(config, [
             "def.svg",
+            "loader.js",
             "defs.html"
         ], done);
     });
@@ -37,7 +39,8 @@ describe("Sending Correct files downstream", function () {
         };
 
         streamTester(config, [
-            "svg/defs.svg"
+            "svg/defs.svg",
+            "loader.js"
         ], done);
     });
     it("sends DEFS files with Custom PREVIEW", function (done) {
@@ -51,7 +54,45 @@ describe("Sending Correct files downstream", function () {
 
         streamTester(config, [
             "svg/defs.svg",
+            "loader.js",
             "index.html"
+        ], done);
+    });
+    it("sends DEFS files with NO LOADER", function (done) {
+
+        var config = {
+            mode: "defs",
+            loader: false
+        };
+
+        streamTester(config, [
+            "svg/defs.svg",
+            "defs.html"
+        ], done);
+    });
+    it("sends DEFS files with NO LOADER and NO PREVIEW", function (done) {
+
+        var config = {
+            mode: "defs",
+            preview: false,
+            loader: false
+        };
+
+        streamTester(config, [
+            "svg/defs.svg"
+        ], done);
+    });
+    it("sends DEFS files with Custom LOADER", function (done) {
+
+        var config = {
+            mode: "defs",
+            loader: "customLoader.js"
+        };
+
+        streamTester(config, [
+            "svg/defs.svg",
+            "customLoader.js",
+            "defs.html"
         ], done);
     });
 });

--- a/test/specs/symbols.js
+++ b/test/specs/symbols.js
@@ -12,6 +12,7 @@ describe("Sending Correct files downstream", function () {
 
         streamTester(config, [
             "svg/symbols.svg",
+            "loader.js",
             "symbols.html"
         ], done);
     });
@@ -26,6 +27,7 @@ describe("Sending Correct files downstream", function () {
 
         streamTester(config, [
             "sym.svg",
+            "loader.js",
             "symbols.html"
         ], done);
     });
@@ -37,7 +39,8 @@ describe("Sending Correct files downstream", function () {
         };
 
         streamTester(config, [
-            "svg/symbols.svg"
+            "svg/symbols.svg",
+            "loader.js"
         ], done);
     });
     it("sends Symbols files with Custom preview", function (done) {
@@ -51,7 +54,45 @@ describe("Sending Correct files downstream", function () {
 
         streamTester(config, [
             "svg/symbols.svg",
+            "loader.js",
             "index.html"
+        ], done);
+    });
+        it("sends DEFS files with NO LOADER", function (done) {
+
+        var config = {
+            mode: "symbols",
+            loader: false
+        };
+
+        streamTester(config, [
+            "svg/symbols.svg",
+            "symbols.html"
+        ], done);
+    });
+    it("sends DEFS files with NO LOADER and NO PREVIEW", function (done) {
+
+        var config = {
+            mode: "symbols",
+            preview: false,
+            loader: false
+        };
+
+        streamTester(config, [
+            "svg/symbols.svg"
+        ], done);
+    });
+    it("sends DEFS files with Custom LOADER", function (done) {
+
+        var config = {
+            mode: "symbols",
+            loader: "customLoader.js"
+        };
+
+        streamTester(config, [
+            "svg/symbols.svg",
+            "customLoader.js",
+            "symbols.html"
         ], done);
     });
 });

--- a/tmpl/loader.js
+++ b/tmpl/loader.js
@@ -1,0 +1,17 @@
+(function (w, d) {
+    var pathToSvg = '{loaderPath}';
+    if (!w.XMLHttpRequest) return false;
+    w.addEventListener('DOMContentLoaded', function () {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', pathToSvg, true);
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4) {
+                var el = d.createElement('div');
+                el.style.display = 'none';
+                el.innerHTML = xhr.responseText;
+                d.body.appendChild(el);
+            }
+        };
+        xhr.send();
+    });
+})(window, document);

--- a/tmpl/loader.js
+++ b/tmpl/loader.js
@@ -1,9 +1,8 @@
 (function (w, d) {
-    var pathToSvg = '{loaderPath}';
     if (!w.XMLHttpRequest) return false;
     w.addEventListener('DOMContentLoaded', function () {
         var xhr = new XMLHttpRequest();
-        xhr.open('GET', pathToSvg, true);
+        xhr.open('GET', '{loaderPath}', true);
         xhr.onreadystatechange = function () {
             if (xhr.readyState === 4) {
                 var el = d.createElement('div');

--- a/tmpl/preview-defs.html
+++ b/tmpl/preview-defs.html
@@ -164,7 +164,7 @@
     <h4>Usage:</h4>
     <ol>
         <li>
-            Include the <strong>contents</strong> of the <a href="{config.svg.defs}">SVG file</a> just after the opening <code>&lt;body&gt;</code> tag.
+            EITHER -- Include the <strong>contents</strong> of the <a href="{config.svg.defs}">SVG file</a> just after the opening <code>&lt;body&gt;</code> tag. OR -- Include the <a href="{config.loader}">the AJAX loader script</a> in your HTML. (Make sure the loader request uses the right path to your SVG, relative to where the script is used.)
         </li>
         <li>
             Paste one of the snippets anywhere into your website.

--- a/tmpl/preview-symbol.html
+++ b/tmpl/preview-symbol.html
@@ -164,7 +164,7 @@
     <h4>Usage:</h4>
     <ol>
         <li>
-            Include the <strong>contents</strong> of the <a href="{config.svg.symbols}">SVG file</a> just after the opening <code>&lt;body&gt;</code> tag.
+            EITHER -- Include the <strong>contents</strong> of the <a href="{config.svg.symbols}">SVG file</a> just after the opening <code>&lt;body&gt;</code> tag. OR -- Include the <a href="{config.loader}">the AJAX loader script</a> in your HTML. (Make sure the loader request uses the right path to your SVG, relative to where the script is used.)
         </li>
         <li>
             Paste one of the snippets anywhere into your website.


### PR DESCRIPTION
This is a start on the loader script discussed in https://github.com/shakyShane/gulp-svg-sprites/issues/52.

I created a dust template for `loader.js` and a couple of additional options to customize the filename and the loading path.

I also added to the current tests and changed a few sentences here and there in documentation.

I'm not sure this is ready to be finalized yet but more of a draft. I was looking for your feedback before putting more into it.

Some of the things not quite finished:
- Should uglify/minify the generated `loader.js` so that it's ready to copy-paste directly into the document head, or some similar place.
- Should I add more documentation about this and how to use it, or do you think this is enough? 

So do you think this is on the right track? Thanks!
