### PR TITLE
Symbols Mode Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,6 +326,31 @@ function writeFiles(stream, config, svg, data, cb) {
   if (config.mode === "symbols") {
     template = "symbols";
     preview  = "previewSymbols";
+    
+        stream.push(new File({
+        cwd: "./",
+        base: "./",
+        path: config.svg.sprite,
+        contents: new Buffer(svg)
+    }));
+
+    var cssFile = config.cssFile;
+
+    if (config) {
+        if (config.templates && config.templates.scss) {
+            cssFile = path.extname(cssFile) === ".css" ? cssFile.replace(".css", ".scss") : cssFile;
+        }
+        var tpl = config.templates && config.templates.scss ? temps.scss : temps.css;
+        promises.push(makeFile(tpl, cssFile, stream, data));
+    }
+
+    if (config.preview && config.preview.sprite) {
+        if (config.templates && config.templates.scss) {
+            cssFile = path.extname(cssFile) === ".scss" ? cssFile.replace(".scss", ".css") : cssFile;
+            promises.push(makeFile(temps.css, cssFile, stream, data));
+        }
+        promises.push(makeFile(temps.previewSprite, config.preview.sprite, stream, data));
+    }
   }
 
   makeFile(temps[template], config.svg[template], stream, data).then(function(output) {


### PR DESCRIPTION
This fix is in order to create the CSS files under "SYMBOLS" mode instead of just the default "SPRITES" mode. Otherwise the CSS file will only be created when I comment out my mode: 'symbols' and then I have to switch back. All I did was to copy and paste the previous code und
[Gulp-SVG-SPRITE-TASK-with-symbols.pdf](https://github.com/shakyShane/gulp-svg-sprites/files/964756/Gulp-SVG-SPRITE-TASK-with-symbols.pdf)

er the "SPRITES" mode, although it needs updating, since the it keeps creating an svg folder and sprite.html. 

Thank you,

Attached my Process for creating the SVG Sprites, Thanks