### PR TITLE
Include viewbox in code preview

### DIFF
--- a/tmpl/preview-symbol.html
+++ b/tmpl/preview-symbol.html
@@ -187,7 +187,7 @@
             <br/>
             <button onclick="invertBackground('icon-box-<%= svgItem.name %>')">Invert Background</button>
             <div class="snippet-popover" id="snippet-<%= svgItem.name %>">
-                <pre><code>&lt;svg class=&quot;<%= common %> <%= svgItem.name %>&quot;&gt;&lt;use xlink:href=&quot;#<%= svgItem.name %>&quot;&gt;&lt;/use&gt;&lt;/svg&gt;</code></pre>
+                <pre><code>&lt;svg class=&quot;<%= common %> <%= svgItem.name %>&quot; viewBox=&quot;<%= svgItem.viewBox %>&quot;&gt;&lt;use xlink:href=&quot;#<%= svgItem.name %>&quot;&gt;&lt;/use&gt;&lt;/svg&gt;</code></pre>
                 <button onclick="hidePopover()">Close</button>
             </div>
         </li>


### PR DESCRIPTION
Currently, if viewbox is not included, the parent SVG is at default height, even if width is specified in CSS (downscaling an icon proportionnaly by specifying only the width becomes impossible). I think the spec of SVG2 will remove this requirement, but right now latest Chrome (62.0.3202.94) and Firefox Quantum (58) don't do it, so it's impossible to manage an SVG icon this way.