### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-var SpriteData = require("svg-sprite-data");
-var through2   = require("through2");
-var gutil      = require("gulp-util");
-var File       = gutil.File;
-var fs         = require("fs");
-var Q          = require("q");
-var _          = require("lodash");
-var path       = require("path");
+var SpriteData  = require("svg-sprite-data");
+var through2    = require("through2");
+var PluginError = require("plugin-error");
+var Vinyl       = require("vinyl");
+var fs          = require("fs");
+var Q           = require("q");
+var _           = require("lodash");
+var path        = require("path");
 
 var PLUGIN_NAME = "gulp-svg-sprites";
 
@@ -267,7 +267,7 @@ function transformData(data, config, done) {
  * @param msg
  */
 function error(context, msg) {
-  context.emit("error", new gutil.PluginError(PLUGIN_NAME, msg));
+  context.emit("error", new PluginError(PLUGIN_NAME, msg));
 }
 
 /**
@@ -292,7 +292,7 @@ function writeFiles(stream, config, svg, data, cb) {
   // Create SVG sprite
   if (config.mode === "sprite") {
 
-    stream.push(new File({
+    stream.push(new Vinyl({
         cwd:  "./",
         base: "./",
         path: config.svg.sprite,
@@ -362,7 +362,7 @@ function makeFile(template, fileName, stream, data) {
     return deferred.promise;
   }
 
-  stream.push(new File({
+  stream.push(new Vinyl({
       cwd:  "./",
       base: "./",
       path: fileName,

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "node": ">= 4.0.0"
   },
   "dependencies": {
-    "gulp-util": "3.0.7",
     "lodash": "4.14.1",
+    "plugin-error": "^1.0.1",
     "q": "1.4.1",
     "svg-sprite-data": "3.1.0",
     "svgo": "0.6.6",
     "through2": "2.0.1",
-    "vinyl": "1.2.0"
+    "vinyl": "^2.1.0"
   },
   "keywords": [
     "svg",

--- a/test/specs/init.js
+++ b/test/specs/init.js
@@ -3,6 +3,7 @@
 var File       = require("vinyl");
 var assert     = require("chai").assert;
 var svgSprites = require("../../index");
+var path       = require("path");
 /**
  * @param {Stream} stream
  * @param {Function} cb
@@ -52,7 +53,7 @@ module.exports = streamHelper;
  */
 module.exports.streamTester = function (config, expected, done) {
     streamHelper(svgSprites(config), function (data) {
-        assert.deepEqual(Object.keys(data), expected);
+        assert.deepEqual(Object.keys(data), expected.map(function(item){ return path.normalize(item);}));
         done();
     });
 };


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143