### PR TITLE
Upgrade `lodash` and `svg-sprite-data` to patch vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ test/fixtures/output
 example-stream.js
 doc/
 diff.png
+npm-debug.log
+package-lock.json
+yarn.lock
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-util": "3.0.7",
     "lodash": "^4.17.11",
     "q": "1.4.1",
-    "svg-sprite-data": "3.1.0",
+    "svg-sprite-data": "^3.1.0",
     "svgo": "0.6.6",
     "through2": "2.0.1",
     "vinyl": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "gulp-util": "3.0.7",
-    "lodash": "4.14.1",
+    "lodash": "^4.17.11",
     "q": "1.4.1",
     "svg-sprite-data": "3.1.0",
     "svgo": "0.6.6",


### PR DESCRIPTION
This PR updates the `lodash` and `svg-sprite-data` dependency versions to patch the vulnerability found below. I also went ahead and ignored some common Yarn and NPM files.

This PR assumes that https://github.com/shakyShane/svg-sprite-data/pull/8 will be merged.

```
✗ Low severity vulnerability found in lodash
  Description: Prototype Pollution
  Info: https://snyk.io/vuln/npm:lodash:20180130
  Introduced through: lodash@4.14.1, svg-sprite-data@3.1.0
  From: lodash@4.14.1
  From: svg-sprite-data@3.1.0 > lodash@4.14.1
  Remediation:
    Upgrade direct dependency lodash@4.14.1 to lodash@4.17.5 (triggers upgrades to lodash@4.17.5)
    Some paths have no direct dependency upgrade that can address this issue. Run `snyk wizard` to explore remediation options.
```