### PR TITLE
removed gulp-utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var SpriteData = require("svg-sprite-data");
 var through2   = require("through2");
-var gutil      = require("gulp-util");
-var File       = gutil.File;
+var File       = require("vinyl");
+var PluginError = require("plugin-error");
 var fs         = require("fs");
 var Q          = require("q");
 var _          = require("lodash");
@@ -267,7 +267,7 @@ function transformData(data, config, done) {
  * @param msg
  */
 function error(context, msg) {
-  context.emit("error", new gutil.PluginError(PLUGIN_NAME, msg));
+  context.emit("error", new PluginErrorr(PLUGIN_NAME, msg));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "node": ">= 4.0.0"
   },
   "dependencies": {
-    "gulp-util": "3.0.7",
     "lodash": "4.14.1",
+    "plugin-error": "^1.0.1",
     "q": "1.4.1",
     "svg-sprite-data": "3.1.0",
     "svgo": "0.6.6",


### PR DESCRIPTION
This commit removes gulp-utils because deprecated by removing the warnings when installing the plugin.

